### PR TITLE
Add OpenWeatherMap API key to env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Twitter API credentials
+TWITTER_CONSUMER_KEY=your_consumer_key
+TWITTER_CONSUMER_SECRET=your_consumer_secret
+TWITTER_ACCESS_TOKEN=your_access_token
+TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret
+
+# OpenWeatherMap API key
+OPENWEATHER_API_KEY=e61efa739a563f77ad4e5c319eb7cb64

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ __pycache__/
 
 # Virtual environments
 venv/
-.env
 .env.*
+!/.env
 !/.env.example
 
 # OS files


### PR DESCRIPTION
## Summary
- unignore `.env` and include example exceptions
- add new `.env` file with provided OpenWeatherMap API key

## Testing
- `flake8 weather_bot.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 weather_bot.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ee10518883238ab4203ba9649c92